### PR TITLE
feat: parse any attachments in pickup, save secrets, use did in config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,92 @@
-# Contribution guidelines
+# Contributing to DIDComm V2 Mediator Test Suite
 
-## Commit guidelines
+As a contributor, here are the guidelines we would like you to follow:
 
-## How to contribute
+- [Issues and Bugs](#issue)
+- [Scenario Requests](#feature)
+- [Submission Guidelines](#submit)
 
-## Propose new scenario
+## <a name="issue"></a> Found a Bug?
 
-## Reporting bugs and enhancements to existing scenarios
+If you find a bug in the source code, you can file new issues by selecting a `Bug Report` template on our [Issues submition page](https://github.com/input-output-hk/didcomm-v2-mediator-test-suite/issues/new/choose).
 
+Even better, you can [submit a Pull Request](#submit-pr) with a fix.
+
+## <a name="feature"></a> Missing a feature or a testing scenario?
+
+You can *request* a new feature or testing scenario by [submitting an issue](#submit-issue) to our GitHub Repository.
+If you would like to *implement* a new feature, please consider the size of the change in order to determine the right steps to proceed:
+
+
+## <a name="submit"></a> Submission Guidelines
+
+### <a name="submit-issue"></a> Requesting a new Scenario
+
+You can file new issues by selecting a `Scenario Request` template on our [Issues submition page](https://github.com/input-output-hk/didcomm-v2-mediator-test-suite/issues/new/choose).
+
+### <a name="submit-pr"></a> Submitting a Pull Request (PR)
+
+Before you submit your Pull Request (PR) consider the following guidelines:
+
+1. Search [GitHub](https://github.com/input-output-hk/didcomm-v2-mediator-test-suite/pulls) for an open or closed PR that relates to your submission.
+   You don't want to duplicate existing efforts.
+
+2. Be sure that an issue describes the problem you're fixing, or documents the design for the feature you'd like to add.
+   Discussing the design upfront helps to ensure that we're ready to accept your work.
+
+3. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the https://github.com/input-output-hk/didcomm-v2-mediator-test-suite/ repo.
+
+4. In your forked repository, make your changes in a new git branch:
+
+     ```shell
+     git checkout -b my-fix-branch main
+     ```
+
+5. Create your patch, **including appropriate test cases**.
+
+6. Ensure that all tests and CI checks pass.
+
+7. Commit your changes using a descriptive commit message.
+
+     ```shell
+     git commit --all
+     ```
+   Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
+
+8. Push your branch to GitHub:
+
+   ```shell
+   git push origin my-fix-branch
+   ```
+
+9. In GitHub, send a pull request to `input-output-hk/didcomm-v2-mediator-test-suite:main`.
+
+That's it! Thank you for your contribution!
+
+#### After your pull request is merged
+
+After your pull request is merged, you can safely delete your branch and pull the changes from the main (upstream) repository:
+
+* Delete the remote branch on GitHub either through the GitHub web UI or your local shell as follows:
+
+    ```shell
+    git push origin --delete my-fix-branch
+    ```
+
+* Check out the main branch:
+
+    ```shell
+    git checkout main -f
+    ```
+
+* Delete the local branch:
+
+    ```shell
+    git branch -D my-fix-branch
+    ```
+
+* Update your local `main` with the latest upstream version:
+
+    ```shell
+    git pull --ff upstream main
+    ```

--- a/README.md
+++ b/README.md
@@ -33,11 +33,7 @@ The configuration file is placed at `src/test/resources/mediator.conf`:
 
 ```text
 mediator {
-    url = "http://localhost:8080"
-    url = ${?MEDIATOR_URL}
     did = ${?MEDIATOR_DID}
-    invitation_endpoint = "/invitation"
-    invitation_endpoint = ${?INVITATION_ENDPOINT}
 }
 
 recipient {
@@ -53,9 +49,7 @@ Some things to consider:
 1. `recipient.host` is set to `host.docker.internal` by default to allow running tests VS the Docker containers.
 You could change this to `localhost` if you're working with the mediator and recipient available at the host network.
 2. `recipient.port` is set to `9999` by default to avoid conflicts with other services running on the host machine.
-3. `mediator.url` is set to `http://localhost:8080` by default, please, change it to the actual mediator URL.
-4. `mediator.did` is optional parameter. If not set, then the test suite will try to use `mediator.invitation_endpoint`
-to set to `mediator.did` if it is not explicitly set.
+3. `mediator.did` is mandatory parameter. Please, set it to the actual mediator DID and make sure its service endpoint is correctly set inside Peer DID services.
 
 ## Tools
 

--- a/src/main/kotlin/models/PeerDID.kt
+++ b/src/main/kotlin/models/PeerDID.kt
@@ -25,7 +25,7 @@ class PeerDID(
     val didDocument: String
         get() = org.didcommx.peerdid.resolvePeerDID(did, VerificationMaterialFormatPeerDID.JWK)
 
-    fun getSecretResolverInMemory(): SecretResolverInMemory {
+    fun getSecrets(): Map<String, Secret> {
         fun validateRawKeyLength(key: ByteArray) {
             // for all supported key types now (ED25519 and X25510) the expected size is 32
             if (key.size != 32) {
@@ -62,12 +62,14 @@ class PeerDID(
             VerificationMaterial(VerificationMaterialFormat.JWK, this.jwkForKeyAuthentication.first().toJSONString())
         )
 
-        return SecretResolverInMemory(
-            mapOf(
-                "${this.did}#$keyIdAgreement" to secretKeyAgreement,
-                "${this.did}#$keyIdAuthentication" to secretKeyAuthentication
-            )
+        return mapOf(
+            "${this.did}#$keyIdAgreement" to secretKeyAgreement,
+            "${this.did}#$keyIdAuthentication" to secretKeyAuthentication
         )
+    }
+
+    fun getSecretResolverInMemory(): SecretResolverInMemory {
+        return SecretResolverInMemory(getSecrets())
     }
 
     fun getDidDocResolverInMemory(): DIDDocResolver {

--- a/src/test/kotlin/abilities/CommunicateViaDidcomm.kt
+++ b/src/test/kotlin/abilities/CommunicateViaDidcomm.kt
@@ -15,8 +15,9 @@ import org.didcommx.didcomm.protocols.routing.Routing
 import org.didcommx.didcomm.protocols.routing.WrapInForwardResult
 import org.didcommx.didcomm.secret.SecretResolver
 import org.didcommx.didcomm.utils.fromJsonToMap
+import org.didcommx.didcomm.utils.toJSONString
 
-open class CommunicateViaDidcomm(var mediatorPeerDid: String, serviceEndpoint: String = "") : Ability {
+open class CommunicateViaDidcomm(val mediatorPeerDid: String, serviceEndpoint: String = "") : Ability {
 
     private val didDocResolver = DIDDocResolverPeerDID()
     private val peerDidService = AgentPeerService.makeAgent(serviceEndpoint = serviceEndpoint)
@@ -32,6 +33,8 @@ open class CommunicateViaDidcomm(var mediatorPeerDid: String, serviceEndpoint: S
             return actor.abilityTo(CommunicateViaDidcomm::class.java)
         }
     }
+
+    fun getSecretsJson() = peerDidService.getSecrets().toJSONString()
 
     fun getDid(): String = peerDidService.did
 
@@ -64,5 +67,9 @@ open class CommunicateViaDidcomm(var mediatorPeerDid: String, serviceEndpoint: S
         val didcommMessage = unpackMessage(SerenityRest.lastResponse().asString(), secretResolver)
         Serenity.recordReportData().withTitle("DIDComm Response").andContents(didcommMessage.toString())
         return didcommMessage
+    }
+
+    override fun toString(): String {
+        return "Communicate via DIDComm with mediator $mediatorPeerDid"
     }
 }

--- a/src/test/kotlin/config/MediatorConf.kt
+++ b/src/test/kotlin/config/MediatorConf.kt
@@ -1,9 +1,5 @@
 package config
 
-import com.sksamuel.hoplite.ConfigAlias
-
 data class MediatorConf(
-    val url: String,
-    var did: String?,
-    @ConfigAlias("invitation_endpoint") val invitationEndpoint: String
+    val did: String
 )

--- a/src/test/resources/mediator.conf
+++ b/src/test/resources/mediator.conf
@@ -1,9 +1,5 @@
 mediator {
-    url = "http://localhost:8080"
-    url = ${?MEDIATOR_URL}
     did = ${?MEDIATOR_DID}
-    invitation_endpoint = "/invitation"
-    invitation_endpoint = ${?INVITATION_ENDPOINT}
 }
 
 recipient {


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

* Add contribution guidelines
* Use DID as an entry point for any mediator and take service endpoint URL from it
* Save secrets in reports to be able to encrypt POST request/responses manually
* Add additional checks for pickup protocol
* Support json and base64 attachment types in pickup protocol

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing scenarios)
* [x] Features (e.g. adding new scenarios)
