### PR TITLE
fix: ensure status 2xx is returned instead of 200

### DIFF
--- a/src/test/kotlin/features/pickupmessage/PickupMessageSteps.kt
+++ b/src/test/kotlin/features/pickupmessage/PickupMessageSteps.kt
@@ -1,13 +1,14 @@
 package features.pickupmessage
 
 import abilities.CommunicateViaDidcomm
-import common.*
+import common.DidcommMessageTypes
+import common.Ensure
 import interactions.SendDidcommMessage
 import interactions.SendEncryptedDidcommMessage
 import io.cucumber.java.en.Given
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
-import io.ktor.http.*
+import io.restassured.internal.http.Status
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.json.Json
@@ -15,8 +16,6 @@ import models.MessagePickupStatusBody
 import models.PeerDID
 import net.serenitybdd.rest.SerenityRest
 import net.serenitybdd.screenplay.Actor
-import net.serenitybdd.screenplay.rest.questions.ResponseConsequence
-import org.apache.http.HttpStatus.SC_OK
 import org.didcommx.didcomm.message.Attachment
 import org.didcommx.didcomm.message.Message
 import org.didcommx.didcomm.protocols.routing.ForwardMessage
@@ -43,14 +42,8 @@ class PickupMessageSteps {
             SendEncryptedDidcommMessage(wrapInForwardResult.msgEncrypted.packedMessage)
         )
 
-        sender.should(
-            ResponseConsequence.seeThatResponse {
-                it.statusCode(SC_OK)
-            }
-        )
         sender.attemptsTo(
-            Ensure.that(SerenityRest.lastResponse().statusCode).isEqualTo(SC_OK)
-                .withReportedError("Response status code for POSTing forward message must be $SC_OK!"),
+            Ensure.that(Status.SUCCESS.matches(SerenityRest.lastResponse().statusCode)).isTrue(),
             Ensure.that(SerenityRest.lastResponse().body.prettyPrint()).isEqualTo("")
                 .withReportedError("Response body for POSTing forward message must be empty!")
         )

--- a/src/test/kotlin/features/ping/PingProtocolSteps.kt
+++ b/src/test/kotlin/features/ping/PingProtocolSteps.kt
@@ -7,9 +7,9 @@ import common.Ensure
 import interactions.SendDidcommMessage
 import io.cucumber.java.en.Then
 import io.cucumber.java.en.When
+import io.restassured.internal.http.Status
 import net.serenitybdd.rest.SerenityRest
 import net.serenitybdd.screenplay.Actor
-import org.apache.http.HttpStatus.SC_OK
 import org.didcommx.didcomm.message.Message
 import org.didcommx.didcomm.utils.idGeneratorDefault
 
@@ -31,7 +31,7 @@ class PingProtocolSteps {
     fun recipientGetTrustedPingMessageBackSynchronously(recipient: Actor) {
         val syncResponse = recipient.usingAbilityTo(CommunicateViaDidcomm::class.java).unpackLastDidcommMessage()
         recipient.attemptsTo(
-            Ensure.that(SerenityRest.lastResponse().statusCode).isEqualTo(SC_OK),
+            Ensure.that(Status.SUCCESS.matches(SerenityRest.lastResponse().statusCode)).isTrue(),
             Ensure.that(syncResponse.type).isEqualTo(DidcommMessageTypes.PING_RESPONSE),
             Ensure.that(syncResponse.to!!.first()).isEqualTo(recipient.recall("peerDid"))
         )
@@ -46,7 +46,7 @@ class PingProtocolSteps {
             )
         val didCommResponseMessage = recipient.usingAbilityTo(CommunicateViaDidcomm::class.java).unpackMessage(didCommResponse)
         recipient.attemptsTo(
-            Ensure.that(SerenityRest.lastResponse().statusCode).isEqualTo(SC_OK),
+            Ensure.that(Status.SUCCESS.matches(SerenityRest.lastResponse().statusCode)).isTrue(),
             Ensure.that(didCommResponseMessage.type).isEqualTo(DidcommMessageTypes.PING_RESPONSE),
             Ensure.that(didCommResponseMessage.to!!.first()).isEqualTo(recipient.recall("peerDid"))
         )


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Ensures that `2xx` HTTP state is returned accordingly to specs, instead of checking for 200 exactly.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [x] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing scenarios)
* [ ] Features (e.g. adding new scenarios)
