### PR TITLE
fix: use dejavu in report problem for repeated message

### DIFF
--- a/src/test/kotlin/common/ReportProblemErrors.kt
+++ b/src/test/kotlin/common/ReportProblemErrors.kt
@@ -2,6 +2,7 @@ package common
 
 object ReportProblemErrors {
     val STORAGE = "e.p.me.res.storage"
+    val DEJAVU = "e.p.crypto.message.dejavu"
     val UNSUPPORTED_PROTOCOL = "e.p.msg.unsupported"
     val ERROR = "e.p.error"
     val NOT_ENROLL = "e.p.req.not_enroll"

--- a/src/test/kotlin/features/reportproblem/ReportProblemProtocolSteps.kt
+++ b/src/test/kotlin/features/reportproblem/ReportProblemProtocolSteps.kt
@@ -38,7 +38,7 @@ class ReportProblemProtocolSteps {
         val reportProblemMessage = recipient.usingAbilityTo(CommunicateViaDidcomm::class.java).unpackLastDidcommMessage()
         recipient.attemptsTo(
             Ensure.that(reportProblemMessage.type).isEqualTo(DidcommMessageTypes.PROBLEM_REPORT),
-            Ensure.that(reportProblemMessage.body["code"] as String).isEqualTo(ReportProblemErrors.STORAGE)
+            Ensure.that(reportProblemMessage.body["code"] as String).isEqualTo(ReportProblemErrors.DEJAVU)
         )
     }
 


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Changes the type of error message to `dejavu` for report problem protocol when duplicated message is sent

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [x] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing scenarios)
* [ ] Features (e.g. adding new scenarios)
